### PR TITLE
fix: argument inspection on mutable args

### DIFF
--- a/frameit/cache.py
+++ b/frameit/cache.py
@@ -1,4 +1,3 @@
-import copy
 import json
 import os
 import platform
@@ -12,7 +11,12 @@ from typing import Any, Callable, Dict, Iterable, List, Tuple, Union, get_args
 import pandas as pd
 import polars as pl
 
-from frameit.utils import get_cache_stats, getargspec, parse_package_from_type
+from frameit.utils import (
+    deepcopy,
+    get_cache_stats,
+    getargspec,
+    parse_package_from_type
+)
 
 CHAR_LIMIT = 500
 TIME_LIMIT = 60
@@ -396,8 +400,8 @@ def frameit(
     def wrapper(func):
         @wraps(func)
         def cache(*args, **kwargs):
-            fargs = copy.copy(args)
-            fkwargs = copy.copy(kwargs)
+            fargs = deepcopy(args)
+            fkwargs = deepcopy(kwargs)
 
             if max_size > CACHE_LIMIT:
                 raise ValueError(

--- a/frameit/utils.py
+++ b/frameit/utils.py
@@ -1,3 +1,4 @@
+import copy
 import inspect
 import os
 from time import time
@@ -62,3 +63,34 @@ def get_cache_stats(path) -> Dict[str, Any]:
         stats["total_size"] += memsize
 
     return stats
+
+
+def deepcopy(obj, memo=None):
+    if memo is None:
+        memo = {}
+
+    if id(obj) in memo:
+        return memo[id(obj)]
+
+    if isinstance(obj, (int, str, float, bool)):
+        # For basic types, return a deep copy
+        return copy.deepcopy(obj)
+    elif isinstance(obj, list):
+        # Create a new list and add deep copies of its elements
+        new_list = []
+        memo[id(obj)] = new_list
+        for item in obj:
+            new_list.append(deepcopy(item, memo))
+        return new_list
+    elif isinstance(obj, dict):
+        # Create a new dictionary and add deep copies of its items
+        new_dict = {}
+        memo[id(obj)] = new_dict
+        for key, value in obj.items():
+            new_key = deepcopy(key, memo)
+            new_value = deepcopy(value, memo)
+            new_dict[new_key] = new_value
+        return new_dict
+    else:
+        # For other types, return a shallow copy
+        return copy.copy(obj)


### PR DESCRIPTION
# What Has Changed?

A custom deepcopy method has been incorporated in the caching utilities. The deep copy method is called on argument inspection.

# Raison d'être

In v0.1.0 mutable arguments modified in the wrapped functions were causing failures on cache inspection. Items living in the cache were not being matched to their designated hash_keys. The fix presented in this PR  resolves the aforementioned issue by freezing and isolating arguments in the wrapper, so that the hash_key on inspection is the same as the generated hash_key once the decorated function has been called.

